### PR TITLE
Dictionary extensions

### DIFF
--- a/CollectionOfHelpers/CollectionOfHelpers/CollectionOfHelpers.csproj
+++ b/CollectionOfHelpers/CollectionOfHelpers/CollectionOfHelpers.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="FileExtensions\FileModification.cs" />
     <Compile Include="FileExtensions\FileStatusChecks.cs" />
+    <Compile Include="GeneralExtensions\DictionaryExtensions.cs" />
     <Compile Include="GeneralExtensions\WpfFunctionality.cs" />
     <Compile Include="GeneralExtensions\WpfReadability.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
+++ b/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CollectionOfHelpers.GeneralExtensions
+{
+    public static class DictionaryExtensions
+    {
+        /// <summary>
+        /// Add the key-value pair to the dictionary and return true if the key doesn't already exist in the dictionary. Return false if the key already exists.
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
+        /// <param name="Dictionary"></param>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> Dictionary, TKey key, TValue value)
+        {
+            if (!Dictionary.ContainsKey(key))
+            {
+                Dictionary.Add(key, value);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
+++ b/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
@@ -31,7 +31,16 @@ namespace CollectionOfHelpers.GeneralExtensions
             }
         }
 
-
+        /// <summary>
+        /// If the key exists in the dictionary then update the value associated with the key. If the key doesn't exist then the key-value pari are added to the dictionary.
+        /// NOTE: returns dictionary however the original dictionary is updated as well.
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
+        /// <param name="dictionary"></param>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static Dictionary<TKey, TValue> AddOrUpdate<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {
             if (dictionary.ContainsKey(key))

--- a/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
+++ b/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
@@ -30,5 +30,20 @@ namespace CollectionOfHelpers.GeneralExtensions
                 return false;
             }
         }
+
+
+        public static Dictionary<TKey, TValue> AddOrUpdate<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        {
+            if (dictionary.ContainsKey(key))
+            {
+                dictionary[key] = value;
+            }
+            else
+            {
+                dictionary.Add(key, value);
+            }
+
+            return dictionary;
+        }
     }
 }

--- a/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
+++ b/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
@@ -10,6 +10,7 @@ namespace CollectionOfHelpers.GeneralExtensions
     {
         /// <summary>
         /// Add the key-value pair to the dictionary and return true if the key doesn't already exist in the dictionary. Return false if the key already exists.
+        /// Similar behaviour to Hashset.add() since no exception is thrown.
         /// </summary>
         /// <typeparam name="TKey"></typeparam>
         /// <typeparam name="TValue"></typeparam>

--- a/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
+++ b/CollectionOfHelpers/CollectionOfHelpers/GeneralExtensions/DictionaryExtensions.cs
@@ -41,18 +41,12 @@ namespace CollectionOfHelpers.GeneralExtensions
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static Dictionary<TKey, TValue> AddOrUpdate<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        public static void AddOrUpdate<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {
-            if (dictionary.ContainsKey(key))
+            if (!dictionary.TryAdd(key,value))
             {
                 dictionary[key] = value;
             }
-            else
-            {
-                dictionary.Add(key, value);
-            }
-
-            return dictionary;
         }
     }
 }

--- a/CollectionOfHelpers/CollectionOfHelpersTests/CollectionOfHelpersTests.csproj
+++ b/CollectionOfHelpers/CollectionOfHelpersTests/CollectionOfHelpersTests.csproj
@@ -38,15 +38,12 @@
     <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="mscorlib.4.0.0.0.Fakes">
-      <HintPath>FakesAssemblies\mscorlib.4.0.0.0.Fakes.dll</HintPath>
-    </Reference>
     <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.mocks, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
@@ -54,9 +51,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.4.0.0.0.Fakes">
-      <HintPath>FakesAssemblies\System.4.0.0.0.Fakes.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -66,11 +60,14 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="FileExtensions\FileModificationTests.cs" />
     <Compile Include="PrivateManipulationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CollectionOfHelpers/CollectionOfHelpersTests/CollectionOfHelpersTests.csproj
+++ b/CollectionOfHelpers/CollectionOfHelpersTests/CollectionOfHelpersTests.csproj
@@ -67,7 +67,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <Compile Include="DictionaryExtensions.cs" />
+    <Compile Include="DictionaryExtensionTests.cs" />
     <Compile Include="FileExtensions\FileModificationTests.cs" />
     <Compile Include="PrivateManipulationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CollectionOfHelpers/CollectionOfHelpersTests/DictionaryExtensionTests.cs
+++ b/CollectionOfHelpers/CollectionOfHelpersTests/DictionaryExtensionTests.cs
@@ -12,123 +12,69 @@ namespace CollectionOfHelpersTests
     [TestFixture]
     public class DictionaryExtensionTests
     {
-        [Test]
-        public void Dictionary_tryadd_keyvalueexists()
+        [TestCase("Hi","there",false)]
+        [TestCase("Hi", "you", false)]
+        public void Dictionary_TryAdd_KeyExists(string key, string value, bool expected)
         {
             //Arrange
             var dic = new Dictionary<string, string>();
             dic.Add("Hi", "there");
 
             //act
-            var actual = dic.TryAdd("Hi", "there");
+            var actual = dic.TryAdd(key, value);
 
             //assert
-            Assert.IsFalse(actual);
+            Assert.AreEqual(expected, actual);
             Assert.AreEqual(dic.Count, 1);
         }
 
-        [Test]
-        public void Dictionary_tryadd_keyexists()
+        [TestCase("Hello", "there", true)]
+        [TestCase("Hello", "you", true)]
+        public void Dictionary_TryAdd_KeyDoesntExist(string key, string value, bool expected)
         {
             //Arrange
             var dic = new Dictionary<string, string>();
             dic.Add("Hi", "there");
 
             //act
-            var actual = dic.TryAdd("Hi", "you");
+            var actual = dic.TryAdd(key, value);
 
             //assert
-            Assert.IsFalse(actual);
-            Assert.AreEqual(dic.Count, 1);
-        }
-
-        [Test]
-        public void Dictionary_tryadd_keydoesntexist()
-        {
-            //Arrange
-            var dic = new Dictionary<string, string>();
-            dic.Add("Hi", "there");
-
-            //act
-            var actual = dic.TryAdd("Hello", "there");
-
-            //assert
-            Assert.IsTrue(actual);
+            Assert.AreEqual(expected, actual);
             Assert.AreEqual(dic.Count, 2);
         }
 
-        [Test]
-        public void Dictionary_tryadd_keyvaluedoesntexist()
+        
+        [TestCase("Hi", "there", 1)]
+        [TestCase("Hi", "you", 1)]
+        public void Dictionary_AddOrUpdate_KeyExists(string key, string value, int expected)
         {
             //Arrange
             var dic = new Dictionary<string, string>();
             dic.Add("Hi", "there");
 
             //act
-            var actual = dic.TryAdd("Hello", "you");
+            dic.AddOrUpdate(key, value);
 
             //assert
-            Assert.IsTrue(actual);
-            Assert.AreEqual(dic.Count, 2);
+            Assert.AreEqual(value, dic[key]);
+            Assert.AreEqual(expected, dic.Count);
         }
 
-        [Test]
-        public void Dictionary_AddOrUpdate_keyvalueexists()
+        [TestCase("Hello", "there", 2)]
+        [TestCase("Hello", "you", 2)]
+        public void Dictionary_AddOrUpdate_KeyDoesntExist(string key, string value, int expected)
         {
             //Arrange
             var dic = new Dictionary<string, string>();
             dic.Add("Hi", "there");
 
             //act
-            var actual = dic.AddOrUpdate("Hi", "there");
+            dic.AddOrUpdate(key, value);
 
             //assert
-            Assert.AreEqual(dic.Count, 1);
-        }
-
-        [Test]
-        public void Dictionary_AddOrUpdate_keyexists()
-        {
-            //Arrange
-            var dic = new Dictionary<string, string>();
-            dic.Add("Hi", "there");
-
-            //act
-            var actual = dic.AddOrUpdate("Hi", "you");
-
-            //assert
-            Assert.AreEqual("you", actual["Hi"]);
-            Assert.AreEqual(dic.Count, 1);
-        }
-
-        [Test]
-        public void Dictionary_AddOrUpdate_keydoesntexist()
-        {
-            //Arrange
-            var dic = new Dictionary<string, string>();
-            dic.Add("Hi", "there");
-
-            //act
-            var actual = dic.AddOrUpdate("Hello", "there");
-
-            //assert
-            Assert.AreEqual("there", actual["Hello"]);
-            Assert.AreEqual(dic.Count, 2);
-        }
-
-        [Test]
-        public void Dictionary_AddOrUpdate_keyvaluedoesntexist()
-        {
-            //Arrange
-            var dic = new Dictionary<string, string>();
-            dic.Add("Hi", "there");
-
-            //act
-            var actual = dic.AddOrUpdate("Hello", "you");
-
-            //assert
-            Assert.AreEqual("you", actual["Hello"]);
-            Assert.AreEqual(dic.Count, 2);
+            Assert.AreEqual(value, dic[key]);
+            Assert.AreEqual(expected, dic.Count);
         }
     }
 }

--- a/CollectionOfHelpers/CollectionOfHelpersTests/DictionaryExtensionTests.cs
+++ b/CollectionOfHelpers/CollectionOfHelpersTests/DictionaryExtensionTests.cs
@@ -10,7 +10,7 @@ namespace CollectionOfHelpersTests
     /// Summary description for DictionaryExtensions
     /// </summary>
     [TestFixture]
-    public class DictionaryExtensions
+    public class DictionaryExtensionTests
     {
         [Test]
         public void Dictionary_tryadd_keyvalueexists()
@@ -69,6 +69,65 @@ namespace CollectionOfHelpersTests
 
             //assert
             Assert.IsTrue(actual);
+            Assert.AreEqual(dic.Count, 2);
+        }
+
+        [Test]
+        public void Dictionary_AddOrUpdate_keyvalueexists()
+        {
+            //Arrange
+            var dic = new Dictionary<string, string>();
+            dic.Add("Hi", "there");
+
+            //act
+            var actual = dic.AddOrUpdate("Hi", "there");
+
+            //assert
+            Assert.AreEqual(dic.Count, 1);
+        }
+
+        [Test]
+        public void Dictionary_AddOrUpdate_keyexists()
+        {
+            //Arrange
+            var dic = new Dictionary<string, string>();
+            dic.Add("Hi", "there");
+
+            //act
+            var actual = dic.AddOrUpdate("Hi", "you");
+
+            //assert
+            Assert.AreEqual("you", actual["Hi"]);
+            Assert.AreEqual(dic.Count, 1);
+        }
+
+        [Test]
+        public void Dictionary_AddOrUpdate_keydoesntexist()
+        {
+            //Arrange
+            var dic = new Dictionary<string, string>();
+            dic.Add("Hi", "there");
+
+            //act
+            var actual = dic.AddOrUpdate("Hello", "there");
+
+            //assert
+            Assert.AreEqual("there", actual["Hello"]);
+            Assert.AreEqual(dic.Count, 2);
+        }
+
+        [Test]
+        public void Dictionary_AddOrUpdate_keyvaluedoesntexist()
+        {
+            //Arrange
+            var dic = new Dictionary<string, string>();
+            dic.Add("Hi", "there");
+
+            //act
+            var actual = dic.AddOrUpdate("Hello", "you");
+
+            //assert
+            Assert.AreEqual("you", actual["Hello"]);
             Assert.AreEqual(dic.Count, 2);
         }
     }

--- a/CollectionOfHelpers/CollectionOfHelpersTests/DictionaryExtensions.cs
+++ b/CollectionOfHelpers/CollectionOfHelpersTests/DictionaryExtensions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using NUnit.Framework;
+using CollectionOfHelpers.GeneralExtensions;
+
+namespace CollectionOfHelpersTests
+{
+    /// <summary>
+    /// Summary description for DictionaryExtensions
+    /// </summary>
+    [TestFixture]
+    public class DictionaryExtensions
+    {
+        [Test]
+        public void Dictionary_tryadd_keyvalueexists()
+        {
+            //Arrange
+            var dic = new Dictionary<string, string>();
+            dic.Add("Hi", "there");
+
+            //act
+            var actual = dic.TryAdd("Hi", "there");
+
+            //assert
+            Assert.IsFalse(actual);
+            Assert.AreEqual(dic.Count, 1);
+        }
+
+        [Test]
+        public void Dictionary_tryadd_keyexists()
+        {
+            //Arrange
+            var dic = new Dictionary<string, string>();
+            dic.Add("Hi", "there");
+
+            //act
+            var actual = dic.TryAdd("Hi", "you");
+
+            //assert
+            Assert.IsFalse(actual);
+            Assert.AreEqual(dic.Count, 1);
+        }
+
+        [Test]
+        public void Dictionary_tryadd_keydoesntexist()
+        {
+            //Arrange
+            var dic = new Dictionary<string, string>();
+            dic.Add("Hi", "there");
+
+            //act
+            var actual = dic.TryAdd("Hello", "there");
+
+            //assert
+            Assert.IsTrue(actual);
+            Assert.AreEqual(dic.Count, 2);
+        }
+
+        [Test]
+        public void Dictionary_tryadd_keyvaluedoesntexist()
+        {
+            //Arrange
+            var dic = new Dictionary<string, string>();
+            dic.Add("Hi", "there");
+
+            //act
+            var actual = dic.TryAdd("Hello", "you");
+
+            //assert
+            Assert.IsTrue(actual);
+            Assert.AreEqual(dic.Count, 2);
+        }
+    }
+}

--- a/CollectionOfHelpers/CollectionOfHelpersTests/packages.config
+++ b/CollectionOfHelpers/CollectionOfHelpersTests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NSubstitute" version="2.0.3" targetFramework="net452" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="NUnit" version="3.7.1" targetFramework="net452" />
   <package id="NUnit.Mocks" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Added two Dictionary extension methods:
-tryadd() which returns false if the add operation doesn't work. The exception is handled so that the Dictionary can behave like a Hashset
-addorupdate which adds a key-value pair if the key doesn't exist and updates the value if the key does exist

Testcases have been included for each.